### PR TITLE
Add functions to jump to previous/next highlighted region

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -20,6 +20,14 @@ You can add a hook to enable it when oppening a buffer, as in the code below.
 
 Also, it is [[https://melpa.org/#/region-occurrences-highlighter][available on MELPA]], and that is the preferred installation method.
 
+In order to add keyboard navigation between highlighted regions, bind your preferred keys in the =region-occurrences-highlighter-nav-mode-map= keymap:
+
+#+begin_src emacs-lisp
+(define-key region-occurrences-highlighter-nav-mode-map "\M-n" 'region-occurrences-highlighter-next)
+(define-key region-occurrences-highlighter-nav-mode-map "\M-p" 'region-occurrences-highlighter-prev)
+#+end_src
+
+The =region-occurrences-highlighter-nav-mode-map= map is only active when regions are highlighted, so the keys can have other bindings when no region highlights exist.
 
 * Customization
 These following are available in customize:


### PR DESCRIPTION
I missed being able to jump between highlights like `highlight-symbol-mode` so here it is.

I've not created any default keybindings, as that's not to everybodys liking, but I've provided a keymap that's only active when regions are highlighted, so one can reuse keys that have another meaning when no region is active (I have it co-exist with `flycheck-next/prev-error` which doesn't make much sense with a region anyway).

I was thinking of skipping the keymap entirely, and just point at [selected.el](https://github.com/Kungsgeten/selected.el/tree/master), but apparently that doesn't allow to set keys depending on minor mode, only major mode. 