### PR TITLE
fix: Handle buffer in minibuffer

### DIFF
--- a/region-occurrences-highlighter.el
+++ b/region-occurrences-highlighter.el
@@ -131,7 +131,7 @@
     (region-occurrences-highlighter--update-buffers
      region-occurrences-highlighter--previous-region
      nil)
-    
+
     (setq region-occurrences-highlighter--previous-region nil)
     (region-occurrences-highlighter-nav-mode -1))
 
@@ -148,7 +148,7 @@
             (region-occurrences-highlighter--update-buffers
              region-occurrences-highlighter--previous-region
              str)
-            
+
             (setq region-occurrences-highlighter--previous-region str)
             (region-occurrences-highlighter-nav-mode 1)))))))
 
@@ -165,7 +165,9 @@
                                 (push buffer buffers)))))))
         (select-frame current-frame)
         buffers)
-    (list (current-buffer))))
+    (list (with-selected-window (or (minibuffer-selected-window)
+                                    (selected-window))
+            (current-buffer)))))
 
 (defun region-occurrences-highlighter--update-buffers(previous-region current-region)
   "Update the highlightings in all buffers but the current buffer."


### PR DESCRIPTION
There is a bug with the configuration:

```elisp
(setq region-occurrences-highlighter-all-visible-buffers nil)
```

The region would not go away if we directly execute the command via `M-x`.

This patch fixes this behavior, it will make sure to select the correct buffer even we are in the minibuffer.